### PR TITLE
Add CLI option to preview task order

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,29 @@ airflow webserver --port 8080
 
 ## Usage
 ```python
-from agent_etl import DataOrchestrator
+from agent_orchestrated_etl import DataOrchestrator
 
-orchestrator = DataOrchestrator()
-pipeline = orchestrator.create_pipeline(
+orch = DataOrchestrator()
+pipeline = orch.create_pipeline(
     source="s3://my-bucket/data/",
-    target="postgresql://localhost/warehouse"
 )
 pipeline.execute()
+
+# override the load step
+custom_pipeline = orch.create_pipeline(
+    source="s3://my-bucket/data/",
+    operations={"load": lambda data: print("loaded", data)},
+)
+custom_pipeline.execute()
+```
+
+You can also execute a pipeline via the CLI. Add `--list-tasks` to preview the
+execution order without running any steps:
+
+```bash
+run_pipeline s3 --output results.json --airflow dag.py --dag-id my_dag
+run_pipeline s3 --list-tasks
+generate_dag s3 dag.py --list-tasks
 ```
 
 ## Roadmap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ packages = ["agent_orchestrated_etl"]
 
 [project.scripts]
 generate_dag = "agent_orchestrated_etl.cli:main"
+run_pipeline = "agent_orchestrated_etl.cli:run_pipeline_cmd"

--- a/src/agent_orchestrated_etl/__init__.py
+++ b/src/agent_orchestrated_etl/__init__.py
@@ -1,5 +1,15 @@
 """Agent-Orchestrated ETL package."""
 
-from . import config, core, data_source_analysis, dag_generator, cli
+from . import config, core, data_source_analysis, dag_generator, cli, orchestrator
+from .orchestrator import DataOrchestrator, Pipeline
 
-__all__ = ["config", "core", "data_source_analysis", "dag_generator", "cli"]
+__all__ = [
+    "config",
+    "core",
+    "data_source_analysis",
+    "dag_generator",
+    "cli",
+    "orchestrator",
+    "DataOrchestrator",
+    "Pipeline",
+]

--- a/src/agent_orchestrated_etl/cli.py
+++ b/src/agent_orchestrated_etl/cli.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
+import json
+
 from .data_source_analysis import analyze_source
-from .dag_generator import generate_dag
+from .dag_generator import generate_dag, dag_to_airflow_code
+from . import orchestrator
 
 
 def generate_dag_cmd(args: list[str] | None = None) -> int:
@@ -12,6 +16,16 @@ def generate_dag_cmd(args: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="generate_dag")
     parser.add_argument("source", help="Data source type, e.g. s3 or postgresql")
     parser.add_argument("output", help="Output DAG file path")
+    parser.add_argument(
+        "--list-tasks",
+        action="store_true",
+        help="Print tasks in execution order and exit",
+    )
+    parser.add_argument(
+        "--dag-id",
+        default="generated",
+        help="Airflow DAG ID to use in the generated file",
+    )
     ns = parser.parse_args(args)
 
     try:
@@ -20,12 +34,65 @@ def generate_dag_cmd(args: list[str] | None = None) -> int:
         parser.exit(1, f"{exc}\n")
 
     dag = generate_dag(metadata)
+
+    if ns.list_tasks:
+        for task_id in dag.topological_sort():
+            print(task_id)
+        return 0
+
     out_path = Path(ns.output)
-    lines = ["# Auto-generated DAG\n", "tasks = {\n"]
-    for task_id, task in dag.tasks.items():
-        lines.append(f"    '{task_id}': {sorted(task.downstream)!r},\n")
-    lines.append("}\n")
-    out_path.write_text("".join(lines))
+    out_path.write_text(dag_to_airflow_code(dag, dag_id=ns.dag_id))
+    return 0
+
+
+def run_pipeline_cmd(args: list[str] | None = None) -> int:
+    """Create and execute a pipeline from the given source."""
+    parser = argparse.ArgumentParser(prog="run_pipeline")
+    parser.add_argument("source", help="Data source type, e.g. s3 or postgresql")
+    parser.add_argument(
+        "--output",
+        help="Optional path to write JSON results; prints to stdout if omitted",
+    )
+    parser.add_argument(
+        "--dag-id",
+        default="generated",
+        help="DAG ID to use if also emitting Airflow code",
+    )
+    parser.add_argument(
+        "--airflow",
+        help="Optional path to also write the generated Airflow DAG file",
+    )
+    parser.add_argument(
+        "--list-tasks",
+        action="store_true",
+        help="Print tasks in execution order and exit",
+    )
+    ns = parser.parse_args(args)
+
+    orch = orchestrator.DataOrchestrator()
+    try:
+        pipeline = orch.create_pipeline(ns.source, dag_id=ns.dag_id)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+
+    if ns.list_tasks:
+        for task_id in pipeline.dag.topological_sort():
+            print(task_id)
+        return 0
+
+    results = pipeline.execute()
+    output_text = json.dumps(results, indent=2)
+
+    if ns.output:
+        Path(ns.output).write_text(output_text)
+    else:
+        print(output_text)
+
+    if ns.airflow:
+        Path(ns.airflow).write_text(orch.dag_to_airflow(pipeline))
+
     return 0
 
 

--- a/src/agent_orchestrated_etl/dag_generator.py
+++ b/src/agent_orchestrated_etl/dag_generator.py
@@ -20,9 +20,32 @@ class SimpleDAG:
         self.tasks: Dict[str, Task] = {}
 
     def add_task(self, task_id: str) -> Task:
+        """Add a task to the DAG if it doesn't already exist."""
+        if task_id in self.tasks:
+            return self.tasks[task_id]
+
         task = Task(task_id)
         self.tasks[task_id] = task
         return task
+
+    def topological_sort(self) -> list[str]:
+        """Return task IDs in topological execution order."""
+        order: list[str] = []
+        incoming = {tid: len(t.upstream) for tid, t in self.tasks.items()}
+        ready = sorted([tid for tid, count in incoming.items() if count == 0])
+
+        while ready:
+            task_id = ready.pop(0)
+            order.append(task_id)
+            for downstream in sorted(self.tasks[task_id].downstream):
+                incoming[downstream] -= 1
+                if incoming[downstream] == 0:
+                    ready.append(downstream)
+
+        if len(order) != len(self.tasks):
+            raise ValueError("Cyclic dependency detected")
+
+        return order
 
     def set_dependency(self, upstream_id: str, downstream_id: str) -> None:
         upstream = self.tasks[upstream_id]
@@ -37,12 +60,15 @@ def generate_dag(metadata: Dict) -> SimpleDAG:
     Parameters
     ----------
     metadata:
-        Currently unused placeholder for future logic.
+        Dictionary containing at least ``tables`` and ``fields`` keys. The
+        ``tables`` list is used to create per-table extract, transform, and load
+        tasks.
 
     Returns
     -------
     SimpleDAG
-        A DAG with extract -> transform -> load tasks.
+        A DAG with extract -> transform -> load tasks and additional per-table
+        tasks derived from the provided metadata.
     """
     if not isinstance(metadata, dict) or not {
         "tables",
@@ -57,4 +83,56 @@ def generate_dag(metadata: Dict) -> SimpleDAG:
 
     dag.set_dependency("extract", "transform")
     dag.set_dependency("transform", "load")
+
+    for table in metadata["tables"]:
+        extract_id = f"extract_{table}"
+        transform_id = f"transform_{table}"
+        load_id = f"load_{table}"
+
+        dag.add_task(extract_id)
+        dag.add_task(transform_id)
+        dag.add_task(load_id)
+
+        dag.set_dependency("extract", extract_id)
+        dag.set_dependency(extract_id, transform_id)
+        dag.set_dependency(transform_id, load_id)
+        dag.set_dependency(load_id, "load")
+
     return dag
+
+
+def dag_to_airflow_code(dag: SimpleDAG, dag_id: str = "generated") -> str:
+    """Return Python code defining an Airflow DAG equivalent to ``dag``.
+
+    Parameters
+    ----------
+    dag:
+        The :class:`SimpleDAG` to convert to Airflow syntax.
+    dag_id:
+        Airflow DAG ID to use in the generated code. Defaults to ``"generated"``.
+
+    Returns
+    -------
+    str
+        Python source code for an Airflow DAG using ``EmptyOperator`` tasks.
+    """
+
+    def _var(name: str) -> str:
+        return name.replace("-", "_")
+
+    lines = [
+        "from airflow import DAG",
+        "from airflow.operators.empty import EmptyOperator",
+        "from datetime import datetime",
+        "",
+        f"with DAG('{dag_id}', start_date=datetime(2024, 1, 1), schedule_interval=None) as dag:",
+    ]
+
+    for task_id in sorted(dag.tasks):
+        lines.append(f"    {_var(task_id)} = EmptyOperator(task_id='{task_id}')")
+
+    for task_id in sorted(dag.tasks):
+        for downstream in sorted(dag.tasks[task_id].downstream):
+            lines.append(f"    {_var(task_id)} >> {_var(downstream)}")
+
+    return "\n".join(lines) + "\n"

--- a/src/agent_orchestrated_etl/data_source_analysis.py
+++ b/src/agent_orchestrated_etl/data_source_analysis.py
@@ -20,7 +20,8 @@ def analyze_source(source_type: str) -> Dict[str, List[str]]:
     Returns
     -------
     dict
-        Dictionary with ``tables`` and ``fields`` keys.
+        Dictionary with ``tables`` and ``fields`` keys. Database sources may
+        include multiple tables to allow per-table DAG generation.
 
     Raises
     ------
@@ -32,5 +33,11 @@ def analyze_source(source_type: str) -> Dict[str, List[str]]:
         raise ValueError(f"Unsupported source type: {source_type}")
 
     if normalized == "s3":
+        # In a real implementation this would inspect the bucket to infer
+        # structure. For now we simply return a single objects table.
         return {"tables": ["objects"], "fields": ["key", "size"]}
-    return {"tables": ["example_table"], "fields": ["id", "value"]}
+
+    # Simulate a database with multiple tables so the DAG generator can
+    # create per-table tasks. The specific table names are not important
+    # for current tests but provide a more realistic example.
+    return {"tables": ["users", "orders"], "fields": ["id", "value"]}

--- a/src/agent_orchestrated_etl/orchestrator.py
+++ b/src/agent_orchestrated_etl/orchestrator.py
@@ -1,0 +1,81 @@
+"""Simple orchestrator that builds and executes ETL pipelines."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Any
+
+from . import data_source_analysis, dag_generator
+from .core import primary_data_extraction, transform_data
+
+
+# Placeholder load function for demonstration purposes.
+def load_data(data: Any) -> bool:
+    """Pretend to load data and return success."""
+    return True
+
+
+class Pipeline:
+    """Executable pipeline based on a :class:`dag_generator.SimpleDAG`."""
+
+    def __init__(
+        self,
+        dag: dag_generator.SimpleDAG,
+        operations: Dict[str, Callable[..., Any]],
+        *,
+        dag_id: str = "generated",
+    ) -> None:
+        self.dag = dag
+        self.operations = operations
+        self.dag_id = dag_id
+
+    def execute(self) -> Dict[str, Any]:
+        """Run tasks in topological order and return their results."""
+        results: Dict[str, Any] = {}
+        for task_id in self.dag.topological_sort():
+            func = self.operations.get(task_id)
+            if func is None:
+                results[task_id] = None
+                continue
+
+            if task_id.startswith("transform"):
+                src = results.get(task_id.replace("transform", "extract"))
+                results[task_id] = func(src)
+            elif task_id.startswith("load"):
+                src = results.get(task_id.replace("load", "transform"))
+                results[task_id] = func(src)
+            else:
+                results[task_id] = func()
+        return results
+
+
+class DataOrchestrator:
+    """High-level interface to build and run ETL pipelines."""
+
+    def create_pipeline(
+        self,
+        source: str,
+        *,
+        dag_id: str = "generated",
+        operations: Dict[str, Callable[..., Any]] | None = None,
+    ) -> Pipeline:
+        metadata = data_source_analysis.analyze_source(source)
+        dag = dag_generator.generate_dag(metadata)
+        ops: Dict[str, Callable[..., Any]] = {
+            "extract": primary_data_extraction,
+            "transform": transform_data,
+            "load": load_data,
+        }
+        for table in metadata["tables"]:
+            ops[f"extract_{table}"] = primary_data_extraction
+            ops[f"transform_{table}"] = transform_data
+            ops[f"load_{table}"] = load_data
+
+        if operations:
+            ops.update(operations)
+
+        return Pipeline(dag, ops, dag_id=dag_id)
+
+    def dag_to_airflow(self, pipeline: Pipeline, dag_id: str | None = None) -> str:
+        return dag_generator.dag_to_airflow_code(
+            pipeline.dag, dag_id=dag_id or pipeline.dag_id
+        )

--- a/tests/test_add_cli_command_generate_dag.py
+++ b/tests/test_add_cli_command_generate_dag.py
@@ -24,6 +24,29 @@ def test_cli_outputs_dag_file(tmp_path):
     assert out_file.exists() and out_file.read_text() != ""  # nosec B101
 
 
+def test_cli_custom_dag_id(tmp_path):
+    """CLI writes the provided DAG ID into the file."""
+    out_file = tmp_path / "dag.py"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agent_orchestrated_etl.cli",
+            "s3",
+            str(out_file),
+            "--dag-id",
+            "custom",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )  # nosec B603
+    assert result.returncode == 0  # nosec B101
+    assert "custom" in out_file.read_text()  # nosec B101
+
+
 def test_cli_invalid_source(tmp_path):
     out_file = tmp_path / "dag.py"
     env = os.environ.copy()
@@ -42,3 +65,26 @@ def test_cli_invalid_source(tmp_path):
     )  # nosec B603
     assert result.returncode != 0  # nosec B101
     assert "Unsupported source type" in result.stderr  # nosec B101
+
+
+def test_cli_list_tasks(tmp_path):
+    """--list-tasks prints tasks instead of writing a file."""
+    out_file = tmp_path / "dag.py"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agent_orchestrated_etl.cli",
+            "s3",
+            str(out_file),
+            "--list-tasks",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )  # nosec B603
+    assert result.returncode == 0  # nosec B101
+    assert "extract" in result.stdout  # nosec B101
+    assert not out_file.exists()  # nosec B101

--- a/tests/test_generate_airflow_dag_from_metadata.py
+++ b/tests/test_generate_airflow_dag_from_metadata.py
@@ -17,3 +17,52 @@ def test_task_dependencies():
     assert 'load' in dag.tasks['transform'].downstream  # nosec B101
     assert 'extract' in dag.tasks['transform'].upstream  # nosec B101
     assert 'transform' in dag.tasks['load'].upstream  # nosec B101
+
+
+def test_per_table_tasks_created():
+    """Per-table extract, transform, and load tasks are generated."""
+    metadata = data_source_analysis.analyze_source('postgresql')
+    dag = dag_generator.generate_dag(metadata)
+    for table in metadata['tables']:
+        assert f'extract_{table}' in dag.tasks  # nosec B101
+        assert f'transform_{table}' in dag.tasks  # nosec B101
+        assert f'load_{table}' in dag.tasks  # nosec B101
+        assert f'extract_{table}' in dag.tasks['extract'].downstream  # nosec B101
+        assert f'transform_{table}' in dag.tasks[f'extract_{table}'].downstream  # nosec B101
+        assert f'load_{table}' in dag.tasks[f'transform_{table}'].downstream  # nosec B101
+        assert 'load' in dag.tasks[f'load_{table}'].downstream  # nosec B101
+
+
+def test_dag_to_airflow_code():
+    """Airflow code string contains basic structure and dependencies."""
+    metadata = data_source_analysis.analyze_source('s3')
+    dag = dag_generator.generate_dag(metadata)
+    code = dag_generator.dag_to_airflow_code(dag)
+    assert 'with DAG(' in code  # nosec B101
+    assert 'extract >> transform' in code  # nosec B101
+    assert 'transform >> load' in code  # nosec B101
+
+
+def test_dag_to_airflow_code_custom_id():
+    """The DAG ID parameter is reflected in the generated code."""
+    metadata = data_source_analysis.analyze_source('s3')
+    dag = dag_generator.generate_dag(metadata)
+    code = dag_generator.dag_to_airflow_code(dag, dag_id='custom_id')
+    assert "with DAG('custom_id'" in code  # nosec B101
+
+
+def test_topological_sort_returns_valid_order():
+    """Topological sort orders tasks according to dependencies."""
+    metadata = data_source_analysis.analyze_source('postgresql')
+    dag = dag_generator.generate_dag(metadata)
+    order = dag.topological_sort()
+
+    assert set(order) == set(dag.tasks)  # nosec B101
+    assert order.index('extract') < order.index('transform')  # nosec B101
+    assert order.index('transform') < order.index('load')  # nosec B101
+
+    for table in metadata['tables']:
+        assert order.index(f'extract_{table}') > order.index('extract')  # nosec B101
+        assert order.index(f'transform_{table}') > order.index(f'extract_{table}')  # nosec B101
+        assert order.index(f'load_{table}') > order.index(f'transform_{table}')  # nosec B101
+        assert order.index(f'load_{table}') < order.index('load')  # nosec B101

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,23 @@
+from agent_orchestrated_etl import orchestrator
+
+
+def test_pipeline_execution():
+    """DataOrchestrator runs extract, transform, and load steps."""
+    orch = orchestrator.DataOrchestrator()
+    pipeline = orch.create_pipeline("s3")
+    results = pipeline.execute()
+    assert results["extract"] == [1, 2, 3]  # nosec B101
+    assert results["transform"] == [1, 4, 9]  # nosec B101
+    assert results["load"] is True  # nosec B101
+
+
+def test_pipeline_custom_operation():
+    """create_pipeline allows overriding default operations."""
+    orch = orchestrator.DataOrchestrator()
+
+    def always_false(_):
+        return False
+
+    pipeline = orch.create_pipeline("s3", operations={"load": always_false})
+    results = pipeline.execute()
+    assert results["load"] is False  # nosec B101

--- a/tests/test_run_pipeline_cli.py
+++ b/tests/test_run_pipeline_cli.py
@@ -1,0 +1,48 @@
+from agent_orchestrated_etl import cli
+
+
+def test_run_pipeline_cmd(capsys):
+    """run_pipeline command executes the pipeline and prints JSON results."""
+    exit_code = cli.run_pipeline_cmd(["s3"])
+    assert exit_code == 0  # nosec B101
+    out = capsys.readouterr().out
+    assert '"extract"' in out  # nosec B101
+    assert '"load"' in out  # nosec B101
+
+
+def test_run_pipeline_cmd_writes_files(tmp_path):
+    """Results and Airflow DAG are written when paths are provided."""
+    out_json = tmp_path / "results.json"
+    out_dag = tmp_path / "dag.py"
+    exit_code = cli.run_pipeline_cmd(
+        [
+            "postgresql",
+            "--output",
+            str(out_json),
+            "--airflow",
+            str(out_dag),
+            "--dag-id",
+            "custom_dag",
+        ]
+    )
+    assert exit_code == 0  # nosec B101
+    assert out_json.exists()  # nosec B101
+    assert "custom_dag" in out_dag.read_text()  # nosec B101
+
+
+def test_run_pipeline_cmd_list_tasks(capsys):
+    """The --list-tasks option prints task order without execution."""
+    exit_code = cli.run_pipeline_cmd(["s3", "--list-tasks"])
+    assert exit_code == 0  # nosec B101
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0] == "extract"  # nosec B101
+    assert "load" in out[-1]  # nosec B101
+
+
+def test_run_pipeline_cmd_invalid_source(capsys):
+    """Invalid source results in non-zero exit code and error message."""
+    exit_code = cli.run_pipeline_cmd(["mongodb"])
+    assert exit_code == 1  # nosec B101
+    err = capsys.readouterr().err
+    assert "Unsupported source type" in err  # nosec B101
+


### PR DESCRIPTION
## Summary
- add `--list-tasks` flag to `run_pipeline` command
- show example CLI usage for previewing tasks in README
- test the new option prints tasks in order
- allow `generate_dag` to list tasks without writing a file
- handle invalid data sources when running a pipeline

## Testing
- `ruff check .`
- `pytest -q`
- `bandit -r src -q`


------
https://chatgpt.com/codex/tasks/task_e_685e888bfac0832986b07c41e2ccebd4