### PR TITLE
Handle monitor log when pipeline creation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,28 @@ custom_pipeline = orch.create_pipeline(
     operations={"load": lambda data: print("loaded", data)},
 )
 custom_pipeline.execute()
+
+# create a pipeline from a REST API
+api_pipeline = orch.create_pipeline(
+    source="api://example.com/endpoint",
+)
+api_pipeline.execute()
 ```
 
 You can also execute a pipeline via the CLI. Add `--list-tasks` to preview the
-execution order without running any steps:
+execution order without running any steps. Use `--list-sources` to see the
+supported data sources. Pass `--monitor` with a file path to capture task
+events. Logs are appended to the file as each step runs. Monitor logs are
+written even if pipeline creation or execution fails, and the command will exit
+with code ``1`` on errors:
 
 ```bash
 run_pipeline s3 --output results.json --airflow dag.py --dag-id my_dag
 run_pipeline s3 --list-tasks
 generate_dag s3 dag.py --list-tasks
+generate_dag --list-sources
+run_pipeline --list-sources
+run_pipeline s3 --monitor events.log
 ```
 
 ## Roadmap

--- a/src/agent_orchestrated_etl/__init__.py
+++ b/src/agent_orchestrated_etl/__init__.py
@@ -1,7 +1,7 @@
 """Agent-Orchestrated ETL package."""
 
 from . import config, core, data_source_analysis, dag_generator, cli, orchestrator
-from .orchestrator import DataOrchestrator, Pipeline
+from .orchestrator import DataOrchestrator, Pipeline, MonitorAgent
 
 __all__ = [
     "config",
@@ -12,4 +12,5 @@ __all__ = [
     "orchestrator",
     "DataOrchestrator",
     "Pipeline",
+    "MonitorAgent",
 ]

--- a/src/agent_orchestrated_etl/data_source_analysis.py
+++ b/src/agent_orchestrated_etl/data_source_analysis.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Dict, List
 
 
-SUPPORTED_SOURCES = {"s3", "postgresql"}
+SUPPORTED_SOURCES = {"s3", "postgresql", "api"}
+
+
+def supported_sources_text() -> str:
+    """Return supported source types as newline separated text."""
+    return "\n".join(sorted(SUPPORTED_SOURCES))
 
 
 def analyze_source(source_type: str) -> Dict[str, List[str]]:
@@ -15,7 +20,7 @@ def analyze_source(source_type: str) -> Dict[str, List[str]]:
     ----------
     source_type:
         A string representing the data source type. Currently supports
-        ``"s3"`` and ``"postgresql"``.
+        ``"s3"``, ``"postgresql"``, and ``"api"``.
 
     Returns
     -------
@@ -36,6 +41,11 @@ def analyze_source(source_type: str) -> Dict[str, List[str]]:
         # In a real implementation this would inspect the bucket to infer
         # structure. For now we simply return a single objects table.
         return {"tables": ["objects"], "fields": ["key", "size"]}
+
+    if normalized == "api":
+        # Placeholder metadata for a generic REST API source. In a real
+        # implementation this would introspect available endpoints.
+        return {"tables": ["records"], "fields": ["id", "data"]}
 
     # Simulate a database with multiple tables so the DAG generator can
     # create per-table tasks. The specific table names are not important

--- a/tests/test_design_data_source_analysis_module.py
+++ b/tests/test_design_data_source_analysis_module.py
@@ -2,14 +2,21 @@ import pytest
 from agent_orchestrated_etl import data_source_analysis
 
 
-def test_metadata_for_s3_and_postgresql():
-    """Module returns metadata about tables and fields for S3 and PostgreSQL sources"""
-    assert "tables" in data_source_analysis.analyze_source('s3')  # nosec B101
-    assert "fields" in data_source_analysis.analyze_source('s3')  # nosec B101
-    assert "tables" in data_source_analysis.analyze_source('postgresql')  # nosec B101
-    assert "fields" in data_source_analysis.analyze_source('postgresql')  # nosec B101
+def test_metadata_for_supported_sources():
+    """Module returns metadata for all supported sources."""
+    for source in ("s3", "postgresql", "api"):
+        metadata = data_source_analysis.analyze_source(source)
+        assert "tables" in metadata  # nosec B101
+        assert "fields" in metadata  # nosec B101
 
 def test_unsupported_source():
     """Raises ValueError when the source type is unsupported"""
     with pytest.raises(ValueError):
         data_source_analysis.analyze_source('mongodb')  # nosec B101
+
+
+def test_supported_sources_text():
+    """Utility returns newline-separated supported sources."""
+    text = data_source_analysis.supported_sources_text()
+    lines = text.splitlines()
+    assert lines == sorted(data_source_analysis.SUPPORTED_SOURCES)  # nosec B101

--- a/tests/test_generate_airflow_dag_from_metadata.py
+++ b/tests/test_generate_airflow_dag_from_metadata.py
@@ -9,6 +9,13 @@ def test_dag_contains_required_tasks():
     assert {'extract', 'transform', 'load'} <= set(dag.tasks.keys())  # nosec B101
 
 
+def test_dag_generated_for_api_source():
+    """API sources produce a DAG with standard tasks."""
+    metadata = data_source_analysis.analyze_source('api')
+    dag = dag_generator.generate_dag(metadata)
+    assert {'extract', 'transform', 'load'} <= set(dag.tasks.keys())  # nosec B101
+
+
 def test_task_dependencies():
     """Tasks have correct upstream/downstream dependencies"""
     metadata = data_source_analysis.analyze_source('s3')

--- a/tests/test_monitor_agent.py
+++ b/tests/test_monitor_agent.py
@@ -1,0 +1,31 @@
+import pytest
+from agent_orchestrated_etl import orchestrator
+
+
+def test_monitor_logs_pipeline_execution():
+    orch = orchestrator.DataOrchestrator()
+    pipeline = orch.create_pipeline("s3")
+    monitor = orchestrator.MonitorAgent()
+    results = pipeline.execute(monitor=monitor)
+    assert results["load"] is True  # nosec B101
+    assert any("starting extract" in e for e in monitor.events)  # nosec B101
+    assert any("completed load" in e for e in monitor.events)  # nosec B101
+
+
+def test_monitor_logs_errors():
+    orch = orchestrator.DataOrchestrator()
+    pipeline = orch.create_pipeline("s3", operations={"load": lambda _d: 1 / 0})
+    monitor = orchestrator.MonitorAgent()
+    with pytest.raises(ZeroDivisionError):
+        pipeline.execute(monitor=monitor)
+    assert any(e.startswith("ERROR:") for e in monitor.events)  # nosec B101
+
+
+def test_monitor_writes_file(tmp_path):
+    """Events are appended to the provided log file."""
+    log = tmp_path / "events.log"
+    monitor = orchestrator.MonitorAgent(log)
+    monitor.log("start")
+    monitor.error("boom")
+    lines = log.read_text().splitlines()
+    assert lines == ["start", "ERROR: boom"]  # nosec B101


### PR DESCRIPTION
## Summary
- write monitor events when pipeline creation fails
- document the behaviour in README
- add regression test for logging on invalid source
- flush events to file on each log entry so partial logs aren't lost

## Testing
- `ruff check .`
- `bandit -r src -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860003c90488329856f5fb2aa4d01d3

## Summary by Sourcery

Add monitoring capabilities to pipeline execution, including logging to file on each event and errors; extend data source support with a generic "api"; introduce --monitor and --list-sources options in CLI tools; update README documentation; and add comprehensive tests for new features.

New Features:
- Introduce MonitorAgent to capture and write pipeline task events, including errors, to a file.
- Add --monitor option to run_pipeline CLI for writing task event logs even when pipeline creation or execution fails.
- Add --list-sources option to both generate_dag and run_pipeline CLIs to display supported data sources.
- Support a new generic "api" data source in data_source_analysis and CLI commands.

Enhancements:
- Flush monitor events to disk on each log entry to prevent loss of partial logs.
- Enhance Pipeline.execute to log start, completion, and errors of tasks via MonitorAgent.
- Improve CLI argument parsing with optional source/output parameters and clearer error messages.

Documentation:
- Document --monitor and --list-sources flags and API source support in README.

Tests:
- Add tests for MonitorAgent logging behavior, including error scenarios.
- Add regression tests for monitor logs on pipeline creation failures and invalid sources.
- Add CLI tests for --list-sources and API source support in both generate_dag and run_pipeline.
- Extend data_source_analysis tests to cover API source and supported_sources_text utility.