### PR TITLE
Refactor config.py with type annotations and improved env var fallback

### DIFF
--- a/src/agent_orchestrated_etl/config.py
+++ b/src/agent_orchestrated_etl/config.py
@@ -596,7 +596,7 @@ class ConfigChangeHandler(FileSystemEventHandler):
     
     def __init__(self, config_manager: 'ConfigManager'):
         self.config_manager = config_manager
-        self.last_modified = {}
+        self.last_modified: Dict[str, float] = {}
     
     def on_modified(self, event):
         """Handle file modification events."""
@@ -720,7 +720,7 @@ class ConfigManager:
         config.api.timeout = int(os.getenv("AGENT_ETL_API_TIMEOUT", "30"))
         
         # Load logging config - support both prefixed and simple env vars for compatibility
-        config.logging.level = os.getenv("AGENT_ETL_LOG_LEVEL") or os.getenv("LOG_LEVEL", "INFO")
+        config.logging.level = os.getenv("AGENT_ETL_LOG_LEVEL") or os.getenv("LOG_LEVEL") or "INFO"
         config.logging.format = os.getenv("AGENT_ETL_LOG_FORMAT", "json")
         config.logging.output = os.getenv("AGENT_ETL_LOG_OUTPUT", "console")
         config.logging.file_path = os.getenv("AGENT_ETL_LOG_FILE")


### PR DESCRIPTION
## Summary
- Added type annotation for `last_modified` dictionary in `ConfigChangeHandler` class
- Improved environment variable fallback logic for logging level in `ConfigManager` class

## Changes

### ConfigChangeHandler
- Annotated `last_modified` attribute as `Dict[str, float]` for better type safety

### ConfigManager
- Updated logging level configuration to fallback to `"INFO"` if neither `AGENT_ETL_LOG_LEVEL` nor `LOG_LEVEL` environment variables are set

## Test plan
- Verified that the type annotation does not affect runtime behavior
- Confirmed logging level defaults to "INFO" when no relevant environment variables are set
- Ensured no regressions in config loading and file modification handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/41b24b32-db37-48dc-a1c1-6ec2d36adc44

## Summary by Sourcery

Add type annotations for file modification tracking and enhance logging level fallback logic

Enhancements:
- Annotate ConfigChangeHandler.last_modified as Dict[str, float] for improved type safety
- Update ConfigManager to default logging level to “INFO” when neither AGENT_ETL_LOG_LEVEL nor LOG_LEVEL are set